### PR TITLE
[NAMED_SCOPES] HaveNamedScope show the named_scope proxy options in the ...

### DIFF
--- a/lib/remarkable/active_record/macros/validations/have_named_scope_matcher.rb
+++ b/lib/remarkable/active_record/macros/validations/have_named_scope_matcher.rb
@@ -56,7 +56,7 @@ module Remarkable # :nodoc:
           return true if @scope_opts.empty?
           return true if @scope.proxy_options == @scope_opts
           
-          @missing = "#{subject_name} didn't scope itself to #{@scope_opts.inspect}"
+          @missing = "#{subject_name} didn't scope itself to #{@scope_opts.inspect} but #{@scope.proxy_options.inspect}"
           return false
         end
         


### PR DESCRIPTION
...exception

Working on a Rails 2.3.17 project I got 2 specs failing on a `named_scope` and I wasn't able to figure out why it was failing until I showed the proxy_options of that named_scope.

I think this is really useful.
